### PR TITLE
Adding Support for Other Request Methods

### DIFF
--- a/lib/utilities/WebAPI.js
+++ b/lib/utilities/WebAPI.js
@@ -40,9 +40,12 @@ import SessionStore from "../stores/SessionStore";
  */
 
 function _performRequest(method, url, options) {
-  options = (options || {});
-  options.method = method;
-  options.headers = (options.headers || {});
+  options                                 = (options || {});
+  options.method                          = method;
+  options.headers                         = (options.headers || {});
+  options.headers["Accept"]               = "application/json";
+  options.headers["Content-Type"]         = "application/json";
+  options.headers["User-Agent"]           = "Shopify API Flux";
   options.headers[Constants.OAUTH_HEADER] = SessionStore.getAccessToken();
 
   return fetch(`https://${SessionStore.getDomain()}${url}`, options).then(response => {
@@ -74,6 +77,54 @@ class WebAPI {
    */
   get(url, options) {
     return _performRequest("get", url, options);
+  }
+
+  /**
+   * Performs a POST request for the given URL and options, passing the resource as the request body
+   *
+   * @param {string} url - the (relative) URL to get (e.g. `/admin/products.json`)
+   * @param {object} [resource] - the resource to post as the request body
+   * @param {object} [options] - options to pass along to the fetch call
+   *
+   * @return {RequestPromise}
+   */
+  post(url, resource, options) {
+    if (resource) {
+      options      = (options || {});
+      options.body = JSON.stringify(resource);
+    }
+
+    return _performRequest("post", url, options);
+  }
+
+  /**
+   * Performs a PUT request for the given URL and options, passing the resource as the request body
+   *
+   * @param {string} url - the (relative) URL to get (e.g. `/admin/products/1.json`)
+   * @param {object} [resource] - the resource to post as the request body
+   * @param {object} [options] - options to pass along to the fetch call
+   *
+   * @return {RequestPromise}
+   */
+  put(url, resource, options) {
+    if (resource) {
+      options      = (options || {});
+      options.body = JSON.stringify(resource);
+    }
+
+    return _performRequest("put", url, options);
+  }
+
+  /**
+   * Performs a DELETE request for the given URL and options
+   *
+   * @param {string} url - the (relative) URL to get (e.g. `/admin/products/1.json`)
+   * @param {object} [options] - options to pass along to the fetch call
+   *
+   * @return {RequestPromise}
+   */
+  delete(url, options) {
+    return _performRequest("delete", url, options);
   }
 }
 

--- a/lib/utilities/__tests__/WebAPITest.js
+++ b/lib/utilities/__tests__/WebAPITest.js
@@ -4,6 +4,31 @@ jest.dontMock("../WebAPI");
 
 import Constants from "../../Constants";
 
+function actsLikeAnAPICall(method, call) {
+  describe("(Common Behavior)", () => {
+    it(`requests the specified URL using the ${method.toUpperCase()} method`, () => {
+      expect(call.url).toBe("https://example.myshopify.com/someurl");
+      expect(call.options.method).toBe(method);
+    });
+
+    it("sets the user agent appropriately", () => {
+      expect(call.options.headers["User-Agent"]).toBe("Shopify API Flux");
+    });
+
+    it("sets the accept header to application/json", () => {
+      expect(call.options.headers["Accept"]).toBe("application/json");
+    });
+
+    it("sets the content type header to application/json", () => {
+      expect(call.options.headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("includes the shopify api header", () => {
+      expect(call.options.headers[Constants.OAUTH_HEADER]).toBe("my_token");
+    });
+  });
+}
+
 describe("WebAPI", () => {
   var SessionStore, WebAPI;
 
@@ -16,31 +41,74 @@ describe("WebAPI", () => {
   });
 
   describe("get", () => {
-    var url, options;
+    var call = {};
 
     beforeEach(() => {
       WebAPI.get("/someurl", { body: JSON.stringify({ param: "value" }) });
 
-      url     = fetch.mock.calls[0][0];
-      options = fetch.mock.calls[0][1];
+      call.url     = fetch.mock.calls[0][0];
+      call.options = fetch.mock.calls[0][1];
     });
 
-    afterEach(() => {
-      fetch.mockClear();
-    });
-
-    it("requests the specified URL using the GET method", () => {
-      expect(url).toBe("https://example.myshopify.com/someurl");
-      expect(options.method).toBe("get");
-    });
+    actsLikeAnAPICall("get", call);
 
     it("sends request body along with the request", () => {
       let body = JSON.stringify({ param: "value" });
-      expect(options.body).toBe(body);
+      expect(call.options.body).toBe(body);
+    });
+  });
+
+  describe("post", () => {
+    var call = {};
+
+    beforeEach(() => {
+      WebAPI.post("/someurl", { param: "value" });
+
+      call.url     = fetch.mock.calls[0][0];
+      call.options = fetch.mock.calls[0][1];
     });
 
-    it("adds the shopify token header", () => {
-      expect(options.headers[Constants.OAUTH_HEADER]).toBe("my_token");
+    actsLikeAnAPICall("post", call);
+
+    it("sends the resource as the request body", () => {
+      let body = JSON.stringify({ param: "value" });
+      expect(call.options.body).toBe(body);
+    });
+  });
+
+  describe("put", () => {
+    var call = {};
+
+    beforeEach(() => {
+      WebAPI.put("/someurl", { param: "value" });
+
+      call.url     = fetch.mock.calls[0][0];
+      call.options = fetch.mock.calls[0][1];
+    });
+
+    actsLikeAnAPICall("put", call);
+
+    it("sends the resource as the request body", () => {
+      let body = JSON.stringify({ param: "value" });
+      expect(call.options.body).toBe(body);
+    });
+  });
+
+  describe("delete", () => {
+    var call = {};
+
+    beforeEach(() => {
+      WebAPI.delete("/someurl", { body: JSON.stringify({ param: "value" }) });
+
+      call.url     = fetch.mock.calls[0][0];
+      call.options = fetch.mock.calls[0][1];
+    });
+
+    actsLikeAnAPICall("delete", call);
+
+    it("sends request body along with the request", () => {
+      let body = JSON.stringify({ param: "value" });
+      expect(call.options.body).toBe(body);
     });
   });
 });


### PR DESCRIPTION
In preparation for fleshing out the products API, we'll need the ability to post, put and delete via the WebAPI.