### PR TITLE
Handling Request Errors

### DIFF
--- a/lib/ShopifyAPIError.js
+++ b/lib/ShopifyAPIError.js
@@ -1,0 +1,36 @@
+"use strict";
+
+function messageFromResponse(response) {
+  return `API Error (${response.status}): ${response.statusText}`;
+}
+
+/**
+ * A base error class for API errors
+ *
+ * @extends {Error}
+ */
+export default class ShopifyAPIError extends Error {
+  constructor(response) {
+    super(messageFromResponse(response));
+    this._status  = response.status;
+    this._message = messageFromResponse(response);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      Object.defineProperty(this, "stack", { value: (new Error()).stack });
+    }
+  }
+
+  get name() {
+    return this.constructor.name;
+  }
+
+  get status() {
+    return this._status;
+  }
+
+  get message() {
+    return this._message;
+  }
+}

--- a/lib/__tests__/ShopifyAPIErrorTest.js
+++ b/lib/__tests__/ShopifyAPIErrorTest.js
@@ -1,0 +1,23 @@
+"use strict";
+
+import ShopifyAPIError from "../ShopifyAPIError";
+
+describe("ShopifyAPIError", () => {
+  var error;
+
+  beforeEach(() => {
+    error = new ShopifyAPIError({ status: 200, statusText: "Status Text" });
+  });
+
+  it("defines a name property as the exception type", () => {
+    expect(error.name).toBe("ShopifyAPIError");
+  });
+
+  it("copies the status from the response", () => {
+    expect(error.status).toBe(200);
+  });
+
+  it("sets the message property", () => {
+    expect(error.message).toEqual("API Error (200): Status Text");
+  });
+});

--- a/lib/integration/__tests__/BaseAPITest.js
+++ b/lib/integration/__tests__/BaseAPITest.js
@@ -1,0 +1,29 @@
+"use strict";
+
+jest.autoMockOff();
+
+const ShopifyAPI           = require("../../ShopifyAPI");
+const ShopifyAPIError      = require("../../ShopifyAPIError");
+const { Product, Session } = ShopifyAPI;
+
+let ensureRejected = () => {
+  throw new Error("Should have rejected");
+};
+
+describe("Base API", () => {
+  setupIntegrationTest(Session);
+
+  describe("error handling", () => {
+    pit("throws ShopifyAPIError objects when response is not (200, 299)", () => {
+      return Promise.resolve(Product.fetch(1)).then(ensureRejected).catch(error => {
+        expect(error instanceof ShopifyAPIError).toBe(true);
+      });
+    });
+
+    pit("includes the status of the response on the exception", () => {
+      return Promise.resolve(Product.fetch(1)).then(ensureRejected).catch(error => {
+        expect(error.status).toBe(404);
+      });
+    });
+  });
+});

--- a/lib/stores/BaseStore.js
+++ b/lib/stores/BaseStore.js
@@ -4,6 +4,10 @@ import Flux from "flux/utils";
 import _    from "lodash";
 
 function mergeItems(state, items) {
+  if (items.length === 0) {
+    return state;
+  }
+
   let initialState = state.set(items[0].id, items[0]);
 
   return items.reduce((previous, current) => {

--- a/lib/stores/__tests__/BaseStoreTest.js
+++ b/lib/stores/__tests__/BaseStoreTest.js
@@ -122,6 +122,15 @@ describe("Base", () => {
 
         expect(changeEvent.mock.calls.length).toBe(1);
       });
+
+      it("can handle empty items list", () => {
+        dispatcher.dispatch({
+          actionType: Constants.Actions.MERGE_THINGS,
+          items: []
+        });
+
+        expect(changeEvent.mock.calls.length).toBe(0);
+      });
     });
 
     describe("clear", () => {

--- a/lib/utilities/WebAPI.js
+++ b/lib/utilities/WebAPI.js
@@ -1,7 +1,8 @@
 "use strict";
 
-import Constants    from "../Constants";
-import SessionStore from "../stores/SessionStore";
+import Constants       from "../Constants";
+import SessionStore    from "../stores/SessionStore";
+import ShopifyAPIError from "../ShopifyAPIError";
 
 /**
  * A method signature for resolved request promises
@@ -49,6 +50,10 @@ function _performRequest(method, url, options) {
   options.headers[Constants.OAUTH_HEADER] = SessionStore.getAccessToken();
 
   return fetch(`https://${SessionStore.getDomain()}${url}`, options).then(response => {
+    if (!response.ok) {
+      throw new ShopifyAPIError(response);
+    }
+
     return response.json();
   });
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "keymirror",
       "lodash",
       "object-hash",
-      "[Pr]omise"
+      "[Pr]omise",
+      "ShopifyAPIError"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
# The Problem

The Fetch API does not reject promises when a request "fails". Instead, rejecting only occurs on network errors, etc.

This is probably the right move in general, but for this API, it would be much simpler to reject when the response isn't `ok` (status 200-299 inclusive).

# The Solution

Manually reject when responses are not ok (by throwing an Error). I've made a specific class for the error so that callers can use syntax like:

```javascript
Product.fetch(0).then(...).catch(error => {
  if (error.name === "ShopifyAPIError") {
    // 404, 422, 429, 500, etc...
  } else {
    // domain not reachable, or other network error
  }
});
```